### PR TITLE
Autosort arrays of regex alternates

### DIFF
--- a/src/IRegex.ts
+++ b/src/IRegex.ts
@@ -9,6 +9,7 @@ export interface RXPlaceholder {
 export interface RXSettingsBase {
     flags: string
     separator?: string
+    autosort?: boolean
 }
 
 export interface RXSettings extends RXSettingsBase {

--- a/src/autosorter.ts
+++ b/src/autosorter.ts
@@ -1,3 +1,90 @@
+import { RXData } from "./IRegex";
+import { TemplateMapper } from "./templatemapper";
+
 interface IRegexListSorter {
-    sortArray() : string[];
+    autoSort(): RXData
+}
+
+interface RegexDto {
+    quant: RegExp,
+    nonQuant: RegExp
+}
+
+export class AutoSorter {
+    private readonly _regexData: RXData;
+
+    constructor(regexData: RXData) {
+        this._regexData = regexData;
+    }
+
+    public autoSort() {
+        let sortedData: RXData = {};
+        for (const namedGroup in this._regexData) {
+            if (!this._isAutoSortable(this._regexData[namedGroup])) 
+                continue;
+
+            sortedData[namedGroup] = this._sortGroup(<string[]> this._regexData[namedGroup]);
+        }
+        
+        return sortedData;
+    }
+
+    protected _isAutoSortable(group: string[] | string) {
+        return (Array.isArray(group));
+    }
+
+    protected _sortGroup(group: string[]) : string[] {
+        const regexes: RegexDto = {
+            quant: /.\{(\d+),?\s?(\d+)?\}/g,
+            nonQuant: /(?!<=\{)\w+(?!\{|.+\}[}{*+])|(?=\\)[?+*$^{}()\[\]\\]/g
+        };
+
+        const sortLogic = (a: string, b: string) => {
+            return this._getLargestMatchLength(b, regexes) - this._getLargestMatchLength(a, regexes);
+        };
+
+        const patternsWithMetas: string[] = group.filter(element => {
+            return /(?!\\)(?:\*|\+)/.test(element);
+        });
+
+        patternsWithMetas.sort(sortLogic);
+
+        const patternsWithLiterals: string[] = group.filter(element => {
+            return /(?!\\)(?:\*|\+)/.test(element) === false;
+        });
+
+        patternsWithLiterals.sort(sortLogic);
+
+        return patternsWithMetas.concat(patternsWithLiterals);
+    }
+
+    protected _getLargestMatchLength(regexString: string, patterns: RegexDto) : number {
+        let total = 0;
+
+        const matches = regexString.replace(patterns.quant, (match, min, max) => {
+            total += (max) ? parseInt(max) : parseInt(min);
+            return '';
+        });
+
+        const includeInCount = matches.matchAll(patterns.nonQuant);
+
+        if (includeInCount === null)
+            return total;
+
+        for (const match of includeInCount) {
+            total += this._addNonQuant(match);
+        }
+
+        return total;
+    }
+
+    protected _addQuant(match: RegExpMatchArray) : number {
+        const map: any = TemplateMapper.map(match, '(minrange)(maxrange)');
+        return (map.maxrange !== undefined) ? parseInt(map.maxrange) : parseInt(map.minrange);
+    }
+
+    protected _addNonQuant(match: RegExpMatchArray) : number {
+        const map: any = TemplateMapper.map(match, '');
+        return map.fullMatch.length;
+    }
 }

--- a/src/autosorter.ts
+++ b/src/autosorter.ts
@@ -1,0 +1,3 @@
+interface IRegexListSorter {
+    sortArray() : string[];
+}

--- a/src/builderbase.ts
+++ b/src/builderbase.ts
@@ -3,9 +3,9 @@ import { TemplateMapper } from './templatemapper';
 
 // perform sorting on regex data before build methods?
 
-interface LogicObj {
-    pattern: RegExp,
-    fn: any
+interface RegexDto {
+    quant: RegExp,
+    nonQuant: RegExp
 }
 
 export abstract class RegexBuilderBase {
@@ -45,7 +45,8 @@ export abstract class RegexBuilderBase {
     public autoSort() {
         for (const namedGroup in this._regexData) {
             if (this._isAutoSortable(this._regexData[namedGroup])) {
-                this._sortGroup(<string[]> this._regexData[namedGroup]);
+                const sortedGroup = this._sortGroup(<string[]> this._regexData[namedGroup]);
+                console.log(sortedGroup);
             }
         }
     }
@@ -57,71 +58,47 @@ export abstract class RegexBuilderBase {
     }
 
     protected _sortGroup(group: string[]) : string[] {
+        const regexes: RegexDto = {
+            quant: /.\{(\d+),?\s?(\d+)?\}/g,
+            nonQuant: /(?!<=\{)\w+(?!\{|.+\}[}{*+])|(?=\\)[?+*$^{}()\[\]\\]/g
+        };
+
+        const sortLogic = (a: string, b: string) => {
+            return this._getLargestMatchLength(b, regexes) - this._getLargestMatchLength(a, regexes);
+        };
+
         const patternsWithMetas: string[] = group.filter(element => {
             return /(?!\\)(?:\*|\+)/.test(element);
         });
+
+        patternsWithMetas.sort(sortLogic);
 
         const patternsWithLiterals: string[] = group.filter(element => {
             return /(?!\\)(?:\*|\+)/.test(element) === false;
         });
 
-        const quantPattern = /.\{(\d+),?\s?(\d+)?\}/g;  // Replace quants?
-        const nonQuantPattern = /(?!<=\{)\w+(?!\{|.+\}[}{*+])|(?=\\)[?+*$^{}()\[\]\\]/g;
-
-        const sortLogic = (a: string, b: string) => {
-            const aMax = this._calculateMatchLength(a, { pattern: quantPattern, fn: this._addQuant }) 
-                        + this._calculateMatchLength(a, { pattern: nonQuantPattern, fn: this._addNonQuant });
-
-            const bMax = this._calculateMatchLength(b, { pattern: quantPattern, fn: this._addQuant })
-                        + this._calculateMatchLength(b, { pattern: nonQuantPattern, fn: this._addNonQuant });
-            
-            return bMax - aMax;
-        };
-
-        patternsWithMetas.sort(sortLogic);
         patternsWithLiterals.sort(sortLogic);
 
-        const allSorted = patternsWithMetas.concat(patternsWithLiterals);
-        console.log(allSorted);
-
-        return allSorted;
+        return patternsWithMetas.concat(patternsWithLiterals);
     }
 
-    protected _calculateMatchLength(regexString: string, obj: LogicObj) : number {
-        const matchesList = regexString.matchAll(obj.pattern);
+    protected _getLargestMatchLength(regexString: string, patterns: RegexDto) : number {
         let total = 0;
 
-        if (matchesList === null)
+        const matches = regexString.replace(patterns.quant, (match, min, max) => {
+            total += (max) ? parseInt(max) : parseInt(min);
+            return '';
+        });
+
+        const includeInCount = matches.matchAll(patterns.nonQuant);
+
+        if (includeInCount === null)
             return total;
 
-        for (let matches of matchesList) {
-            total += obj.fn(matches);
-        }
-        console.log(total, regexString);
-        return total;
-    }
-
-    protected _calculateMaxMatchLength(regexString: string) : number {
-        const quantPattern = /.\{(\d+),?\s?(\d+)?\}/g;
-        const nonQuantPattern = /(?!<=\{)\w+(?!\{)|(?=\\)[?+*$^{}()\[\]\\]/g;
-        let total = 0;
-
-        const matches = regexString.matchAll(quantPattern);
-        const includeInCount = regexString.matchAll(nonQuantPattern);
-
-        if (matches !== null) {
-            for (let match of matches) {
-                total += this._addQuant(match);
-            }
+        for (const match of includeInCount) {
+            total += this._addNonQuant(match);
         }
 
-        if (includeInCount !== null) {
-            for (const match of includeInCount) {
-                total += this._addNonQuant(match);
-            }
-        }
-
-        console.log(total, regexString);
         return total;
     }
 

--- a/src/builderbase.ts
+++ b/src/builderbase.ts
@@ -1,12 +1,4 @@
 import { RXData, RXPlaceholder, RXSettingsBase } from './IRegex';
-import { TemplateMapper } from './templatemapper';
-
-// perform sorting on regex data before build methods?
-
-interface RegexDto {
-    quant: RegExp,
-    nonQuant: RegExp
-}
 
 export abstract class RegexBuilderBase {
     protected _regexData: RXData;
@@ -34,82 +26,10 @@ export abstract class RegexBuilderBase {
     }
 
     protected _substitutePlaceholder(group: string) : string {
-        const swap = (match: string, p1: string) => {
-            if (!this._placeholderData[p1]) throw new Error(`found undefined placeholder ${match} in regex data`);
+        return group.replace(/~~(\w+)~~/, (match: string, p1: string) => {
+            if (!this._placeholderData[p1]) throw new Error(`undefined placeholder ${match} in regex data`);
             return this._buildGroup(this._placeholderData[p1]);
-        };
-
-        return group.replace(/~~(\w+)~~/, swap);
-    }
-
-    public autoSort() {
-        for (const namedGroup in this._regexData) {
-            if (this._isAutoSortable(this._regexData[namedGroup])) {
-                const sortedGroup = this._sortGroup(<string[]> this._regexData[namedGroup]);
-                console.log(sortedGroup);
-            }
-        }
-    }
-
-    protected _isAutoSortable(group: string[] | string) {
-        return (Array.isArray(group) 
-                && this._settings.autosort === true 
-                && this._settings.separator === ('|' || undefined));
-    }
-
-    protected _sortGroup(group: string[]) : string[] {
-        const regexes: RegexDto = {
-            quant: /.\{(\d+),?\s?(\d+)?\}/g,
-            nonQuant: /(?!<=\{)\w+(?!\{|.+\}[}{*+])|(?=\\)[?+*$^{}()\[\]\\]/g
-        };
-
-        const sortLogic = (a: string, b: string) => {
-            return this._getLargestMatchLength(b, regexes) - this._getLargestMatchLength(a, regexes);
-        };
-
-        const patternsWithMetas: string[] = group.filter(element => {
-            return /(?!\\)(?:\*|\+)/.test(element);
         });
-
-        patternsWithMetas.sort(sortLogic);
-
-        const patternsWithLiterals: string[] = group.filter(element => {
-            return /(?!\\)(?:\*|\+)/.test(element) === false;
-        });
-
-        patternsWithLiterals.sort(sortLogic);
-
-        return patternsWithMetas.concat(patternsWithLiterals);
-    }
-
-    protected _getLargestMatchLength(regexString: string, patterns: RegexDto) : number {
-        let total = 0;
-
-        const matches = regexString.replace(patterns.quant, (match, min, max) => {
-            total += (max) ? parseInt(max) : parseInt(min);
-            return '';
-        });
-
-        const includeInCount = matches.matchAll(patterns.nonQuant);
-
-        if (includeInCount === null)
-            return total;
-
-        for (const match of includeInCount) {
-            total += this._addNonQuant(match);
-        }
-
-        return total;
-    }
-
-    protected _addQuant(match: RegExpMatchArray) : number {
-        const map: any = TemplateMapper.map(match, '(minrange)(maxrange)');
-        return (map.maxrange !== undefined) ? parseInt(map.maxrange) : parseInt(map.minrange);
-    }
-
-    protected _addNonQuant(match: RegExpMatchArray) : number {
-        const map: any = TemplateMapper.map(match, '');
-        return map.fullMatch.length;
     }
 
 }

--- a/src/builderbase.ts
+++ b/src/builderbase.ts
@@ -3,6 +3,11 @@ import { TemplateMapper } from './templatemapper';
 
 // perform sorting on regex data before build methods?
 
+interface LogicObj {
+    pattern: RegExp,
+    fn: any
+}
+
 export abstract class RegexBuilderBase {
     protected _regexData: RXData;
     protected _settings: RXSettingsBase;
@@ -24,6 +29,19 @@ export abstract class RegexBuilderBase {
         return template;
     }
 
+    protected _buildGroup(group: string[] | string) : string {
+        return (Array.isArray(group)) ? group.join(this._settings.separator || '|') : group;
+    }
+
+    protected _substitutePlaceholder(group: string) : string {
+        const swap = (match: string, p1: string) => {
+            if (!this._placeholderData[p1]) throw new Error(`found undefined placeholder ${match} in regex data`);
+            return this._buildGroup(this._placeholderData[p1]);
+        };
+
+        return group.replace(/~~(\w+)~~/, swap);
+    }
+
     public autoSort() {
         for (const namedGroup in this._regexData) {
             if (this._isAutoSortable(this._regexData[namedGroup])) {
@@ -38,78 +56,83 @@ export abstract class RegexBuilderBase {
                 && this._settings.separator === ('|' || undefined));
     }
 
-    // sort metas descending min length
     protected _sortGroup(group: string[]) : string[] {
-        const metaList: string[] = group.filter((element, index) => {
+        const patternsWithMetas: string[] = group.filter(element => {
             return /(?!\\)(?:\*|\+)/.test(element);
         });
 
-        const litList: string[] = group.filter((element, index) => {
+        const patternsWithLiterals: string[] = group.filter(element => {
             return /(?!\\)(?:\*|\+)/.test(element) === false;
         });
 
-        metaList.sort((a: string, b: string) => {
-            const first = this._calculateMinMatchLength(a);
-            const second = this._calculateMinMatchLength(b);
-            return second - first;
-        });
-        
-        litList.sort((a: string, b: string) => {
-            const first = this._calculateMaxMatchLength(a);
-            const second = this._calculateMaxMatchLength(b);
-            return second - first;
-        });
+        const quantPattern = /.\{(\d+),?\s?(\d+)?\}/g;  // Replace quants?
+        const nonQuantPattern = /(?!<=\{)\w+(?!\{|.+\}[}{*+])|(?=\\)[?+*$^{}()\[\]\\]/g;
 
-        const allSorted = metaList.concat(litList);
+        const sortLogic = (a: string, b: string) => {
+            const aMax = this._calculateMatchLength(a, { pattern: quantPattern, fn: this._addQuant }) 
+                        + this._calculateMatchLength(a, { pattern: nonQuantPattern, fn: this._addNonQuant });
+
+            const bMax = this._calculateMatchLength(b, { pattern: quantPattern, fn: this._addQuant })
+                        + this._calculateMatchLength(b, { pattern: nonQuantPattern, fn: this._addNonQuant });
+            
+            return bMax - aMax;
+        };
+
+        patternsWithMetas.sort(sortLogic);
+        patternsWithLiterals.sort(sortLogic);
+
+        const allSorted = patternsWithMetas.concat(patternsWithLiterals);
         console.log(allSorted);
 
         return allSorted;
     }
 
-    protected _calculateMinMatchLength(regexString: string) : number {
-        const countables = /\w+|(?=\\)[?+*$^{}()\[\]\\]/g
+    protected _calculateMatchLength(regexString: string, obj: LogicObj) : number {
+        const matchesList = regexString.matchAll(obj.pattern);
         let total = 0;
 
-        const includeInCount = regexString.match(countables);
-        console.log(includeInCount);
-
-        if (includeInCount !== null) {
-            for (const match of includeInCount) {
-                total += match.length;
-            }
+        if (matchesList === null)
             return total;
+
+        for (let matches of matchesList) {
+            total += obj.fn(matches);
         }
-
-        return 1;
-    }
-
-    // if * or + present theoretical limit is infinite -> sort these by minimum amount instead (10 -> inf, 2 -> inf, 10-28, 7)
-
-    protected _calculateMaxMatchLength(regexString: string) : number {
-        const quantPattern = /.\{(\d+),?\s?(\d+)?\}/;
-
-        let total = 0;
-
-        const finiteQuants = regexString.match(quantPattern);
-        if (finiteQuants !== null) {
-            const map: any = TemplateMapper.map(finiteQuants, '(minrange)(maxrange)');
-            total += (map.maxrange !== undefined) ? parseInt(map.maxrange) : parseInt(map.minrange);
-        }
-        
+        console.log(total, regexString);
         return total;
     }
 
-    protected _buildGroup(group: string[] | string) : string {
-        return (Array.isArray(group)) ? group.join(this._settings.separator || '|') : group;
+    protected _calculateMaxMatchLength(regexString: string) : number {
+        const quantPattern = /.\{(\d+),?\s?(\d+)?\}/g;
+        const nonQuantPattern = /(?!<=\{)\w+(?!\{)|(?=\\)[?+*$^{}()\[\]\\]/g;
+        let total = 0;
+
+        const matches = regexString.matchAll(quantPattern);
+        const includeInCount = regexString.matchAll(nonQuantPattern);
+
+        if (matches !== null) {
+            for (let match of matches) {
+                total += this._addQuant(match);
+            }
+        }
+
+        if (includeInCount !== null) {
+            for (const match of includeInCount) {
+                total += this._addNonQuant(match);
+            }
+        }
+
+        console.log(total, regexString);
+        return total;
     }
 
-    protected _substitutePlaceholder(group: string) : string {
-        const swap = (match: string, p1: string) => {
-            if (!this._placeholderData[p1]) throw new Error(`found undefined placeholder ${match} in regex data`);
-            return this._buildGroup(this._placeholderData[p1]);
-        };
+    protected _addQuant(match: RegExpMatchArray) : number {
+        const map: any = TemplateMapper.map(match, '(minrange)(maxrange)');
+        return (map.maxrange !== undefined) ? parseInt(map.maxrange) : parseInt(map.minrange);
+    }
 
-        return group.replace(/~~(\w+)~~/, swap);
+    protected _addNonQuant(match: RegExpMatchArray) : number {
+        const map: any = TemplateMapper.map(match, '');
+        return map.fullMatch.length;
     }
 
 }

--- a/src/builderbase.ts
+++ b/src/builderbase.ts
@@ -1,9 +1,11 @@
 import { RXData, RXPlaceholder, RXSettingsBase } from './IRegex';
 
+// perform sorting on regex data before build methods
+
 export abstract class RegexBuilderBase {
     protected _regexData: RXData;
     protected _settings: RXSettingsBase;
-    protected _placeholderData: RXPlaceholder ;
+    protected _placeholderData: RXPlaceholder;
 
     constructor(regexData: RXData, settings: RXSettingsBase, placeholders?: RXPlaceholder) {
         this._regexData = regexData;
@@ -13,12 +15,56 @@ export abstract class RegexBuilderBase {
 
     protected _buildTemplate(template: string) : string {
         for (const namedGroup in this._regexData) {
-            let builtGroup = this._buildGroup(this._regexData[namedGroup]);
-            let subbedGroup = this._substitutePlaceholder(builtGroup);
+            const builtGroup = this._buildGroup(this._regexData[namedGroup]);
+            const subbedGroup = this._substitutePlaceholder(builtGroup);
             template = template.replace(new RegExp(`${namedGroup}(?=\\W)`, 'g'), subbedGroup);
         }
         
         return template;
+    }
+
+    public autoSort() {
+        console.log('started auto sort');
+        for (const namedGroup in this._regexData) {
+            if (this._isAutoSortable(this._regexData[namedGroup])) {
+                this._sortGroup(<string[]> this._regexData[namedGroup]);
+            }
+        }
+    }
+
+    protected _isAutoSortable(group: string[] | string) {
+        return (Array.isArray(group) 
+                && this._settings.autosort === true 
+                && this._settings.separator === ('|' || undefined));
+    }
+
+    protected _sortGroup(group: string[]) : string[] {
+        console.log('unsorted', group);
+        group.sort((a: string, b: string) => {
+            const first = this._calculateMaxMatchLength(a);
+            const second = this._calculateMaxMatchLength(b);
+            console.log(first, second);
+            return second - first;
+        });
+
+        console.log('sorted', group);
+        return group;
+    }
+
+    // {n} {n,m} +* ?
+    // recursive quantifier match
+    // if found add amount to sum and call match again from lastIndex;
+
+    protected _calculateMaxMatchLength(regexString: string) : number {
+        const quantPattern = /.\{(\d+),?\s?(\d+)?\}/;
+        const matches = regexString.match(quantPattern);
+
+        if (!matches) return 0;
+
+        let total = 0;
+        total += (matches[2] !== undefined) ?  parseInt(matches[2]) : parseInt(matches[1]);
+
+        return total;
     }
 
     protected _buildGroup(group: string[] | string) : string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,5 @@ export { RXData, RXSettings, RXListSettings, RXPlaceholder } from './IRegex';
 export { TemplateBuilder, TemplateListBuilder} from './templatebuilder';
 export { TemplateMapper } from './templatemapper';
 export { AugmentedExp } from './augmentedExp';
+export { AutoSorter } from './autosorter';
 export { Regexpress } from './regexpress';

--- a/src/regexpress.ts
+++ b/src/regexpress.ts
@@ -4,16 +4,28 @@ export class Regexpress {
 
     constructor() {}
 
-    autoSort(RXData: rxp.RXData, RXSettings: rxp.RXSettings, RXPlaceholder?: rxp.RXPlaceholder) {
-        return new rxp.TemplateBuilder(RXData, RXSettings, RXPlaceholder).autoSort();
+    autoSort(RXData: rxp.RXData) {
+        return new rxp.AutoSorter(RXData).autoSort();
     }
 
     buildRegex(RXData: rxp.RXData, RXSettings: rxp.RXSettings, RXPlaceholder?: rxp.RXPlaceholder) {
+        if (this._isAutoSortable(RXSettings)) {
+            RXData = this.autoSort(RXData);
+        }
+        
         return new rxp.TemplateBuilder(RXData, RXSettings, RXPlaceholder).build();
     }
 
     buildRegexes(RXData: rxp.RXData, RXListSettings: rxp.RXListSettings, RXPlaceholder?: rxp.RXPlaceholder) {
+        if (this._isAutoSortable(RXListSettings)) {
+            RXData = this.autoSort(RXData);
+        }
+
         return new rxp.TemplateListBuilder(RXData, RXListSettings, RXPlaceholder).build();
+    }
+
+    private _isAutoSortable(RXSettings: rxp.RXSettings | rxp.RXListSettings) {
+        return (RXSettings.autosort && RXSettings.separator === ('|' || undefined));
     }
 
     mapTemplate(results: RegExpMatchArray | null, template: string) {

--- a/src/regexpress.ts
+++ b/src/regexpress.ts
@@ -4,6 +4,10 @@ export class Regexpress {
 
     constructor() {}
 
+    autoSort(RXData: rxp.RXData, RXSettings: rxp.RXSettings, RXPlaceholder?: rxp.RXPlaceholder) {
+        return new rxp.TemplateBuilder(RXData, RXSettings, RXPlaceholder).autoSort();
+    }
+
     buildRegex(RXData: rxp.RXData, RXSettings: rxp.RXSettings, RXPlaceholder?: rxp.RXPlaceholder) {
         return new rxp.TemplateBuilder(RXData, RXSettings, RXPlaceholder).build();
     }

--- a/src/templatebuilder.ts
+++ b/src/templatebuilder.ts
@@ -2,10 +2,6 @@ import { AugmentedExp } from './augmentedExp';
 import { RegexBuilderBase } from './builderbase';
 import { RXListSettings, RXSettings, RXData, RXPlaceholder } from './IRegex';
 
-interface Buildable {
-    build() : RegExp;
-}
-
 export class TemplateBuilder extends RegexBuilderBase {
     protected _settings: RXSettings;
 

--- a/test/RegexBuilder.test.ts
+++ b/test/RegexBuilder.test.ts
@@ -93,3 +93,33 @@ describe('regex builder logic tests', () => {
     });
   
 });
+
+const regexDataAutoSortMock = {
+    literalQuants: [
+        'a{1}',
+        'b{1}',
+        'c{1,100}'
+    ]
+};
+
+const autoSortSettingsMock = {
+    template: '(literalQuants)',
+    flags: ''
+};
+
+describe('regex counter tests', () => {
+
+    it('should sum up regex literal quantifiers', () => {
+        expect(
+            new TemplateBuilder(regexDataAutoSortMock, autoSortSettingsMock).autoSort()
+        ).to.deep.equal(['c{1,100}','a{1}','b{1}']);
+    });
+  
+});
+
+    // metaQuantifiers: [
+    //     '\\d+',
+    //     '\\d*',
+    //     'a+',
+    //     'a*'
+    // ]

--- a/test/RegexBuilder.test.ts
+++ b/test/RegexBuilder.test.ts
@@ -1,4 +1,4 @@
-import { TemplateBuilder } from '../src/index';
+import { TemplateBuilder, AutoSorter, Regexpress } from '../src/index';
 
 import * as mocha from  'mocha';
 import * as chai from 'chai';
@@ -89,37 +89,62 @@ describe('regex builder logic tests', () => {
 
     it('should throw an error when an undefined placeholder is encountered', () => {
         expect(() => new TemplateBuilder(mockRegexDataWithUndefinedPlaceholder, mockSettings, mockPlaceholder).build())
-            .to.throw('found undefined placeholder ~~holdplacer~~ in regex data');
+            .to.throw('undefined placeholder ~~holdplacer~~ in regex data');
     });
   
 });
 
 const regexDataAutoSortMock = {
-    literalQuants: [
+    Quantifiers: [
         'a{1}',
-        'b{1}',
-        'c{1,100}'
+        'a{3}fb*c{1,10}',
+        'd*abc+f{2}',
+        'c{1,100}',
+        'd{5, 17}',
+        'e{5}',
+        'abc+',
+        'a+'
     ]
 };
 
-const autoSortSettingsMock = {
-    template: '(literalQuants)',
-    flags: ''
+const autoSortSettingTrueMock = {
+    template: '(Quantifiers)',
+    flags: '',
+    autosort: true,
+    separator: '|'
 };
 
-describe('regex counter tests', () => {
+const autoSortSettingFalseMock = {
+    template: '(Quantifiers)',
+    flags: '',
+    autosort: false,
+    separator: '|'
+};
 
-    it('should sum up regex literal quantifiers', () => {
-        expect(
-            new TemplateBuilder(regexDataAutoSortMock, autoSortSettingsMock).autoSort()
-        ).to.deep.equal(['c{1,100}','a{1}','b{1}']);
+describe('autosorter tests', () => {
+    
+    it('should sort from data with autosort setting = true', () => {
+        expect(new Regexpress().buildRegex(regexDataAutoSortMock, autoSortSettingFalseMock))
+            .to.deep.equal(/(a{1}|a{3}fb*c{1,10}|d*abc+f{2}|c{1,100}|d{5, 17}|e{5}|abc+|a+)/);
+    });
+
+    it('should not sort from data with autosort setting = false', () => {
+        expect(new Regexpress().buildRegex(regexDataAutoSortMock, autoSortSettingTrueMock))
+            .to.deep.equal(/(a{3}fb*c{1,10}|d*abc+f{2}|abc+|a+|c{1,100}|d{5, 17}|e{5}|a{1})/);
+    });
+
+    it('should sort from code after direct call to autoSort method', () => {
+        expect(new AutoSorter(regexDataAutoSortMock).autoSort())
+            .to.deep.equal({ Quantifiers: [
+            'a{3}fb*c{1,10}',
+            'd*abc+f{2}',
+            'abc+',
+            'a+',
+            'c{1,100}',
+            'd{5, 17}',
+            'e{5}',
+            'a{1}'
+        ]});
     });
   
 });
-
-    // metaQuantifiers: [
-    //     '\\d+',
-    //     '\\d*',
-    //     'a+',
-    //     'a*'
-    // ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "es2015",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["es2020.string"],                 /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
Added a class that enables sorting of regex alternates in regex data groups by calculating each element's theoretical max matching length. This way search accuracy is maintained when two alternates with identical starts are searched for

regExample:

"The code is AF234"
"The code is AF234-B, the id 7"

The algorithm will likely need some additional testing but is now operational in the Regexpress library.